### PR TITLE
fix: send much less data on taxonomy sorting

### DIFF
--- a/src/main/modules/serlo_sortable_list.js
+++ b/src/main/modules/serlo_sortable_list.js
@@ -52,6 +52,46 @@ SortableList = function () {
       return array
     }
 
+    /**
+     * @function cleanUnchangedParents
+     * @param {Array}
+     *
+     * Searches for unchanged subtrees and removes all children in that tree.
+     * This helps reduce the changes send to the server A LOT in most cases.
+     **/
+    function cleanUnchangedParents (array) {
+      _.each(array, function (parent) {
+        if (parent.children) {
+          const originalParent = findDeepElementWithId(originalData, parent.id)
+          if (_.isEqual(parent, originalParent)) {
+            delete parent.children
+          } else {
+            cleanUnchangedParents(parent.children)
+          }
+        }
+      })
+      return array;
+    }
+
+    function findDeepElementWithId(array, id) {
+      const elementOnThisLevel = _.findWhere(array, {id: id})
+      if (elementOnThisLevel) {
+        return elementOnThisLevel
+      } else {
+        let elementOnDeeperLevel
+        _.find(array, function (child) {
+           if (!child.children) {
+              return false
+           }
+           elementOnDeeperLevel = findDeepElementWithId(child.children, id)
+           if (elementOnDeeperLevel) {
+             return true
+           }
+        })
+        return elementOnDeeperLevel
+      }
+    }
+
     function storeOriginalData () {
       originalHTML = $instance
         .find('> ol')
@@ -108,6 +148,7 @@ SortableList = function () {
       } else {
         $saveBtn.hide()
       }
+      updatedData = cleanUnchangedParents(updatedData)
     })
 
     $saveBtn.click(function (e) {


### PR DESCRIPTION
(probably) fixes https://github.com/serlo-org/athene2/issues/332

previously our SortableList code serialized the whole tree and send it to the server, where every element then was updated. I cleaned the data for the post request by removing unchanged subtrees. This should fix the referenced issue - which probably was caused by some timeout / too many changes / ... :tada: :tada: