### PR TITLE
feat: cloudflare workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ typings/
 
 # Bundled code
 dist
+dist-cf

--- a/__tests__/cloudflare-workers/index.js
+++ b/__tests__/cloudflare-workers/index.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 import { handleRequest } from '../../src/cloudflare-workers'
 
 expect.extend({

--- a/__tests__/cloudflare-workers/index.js
+++ b/__tests__/cloudflare-workers/index.js
@@ -1,0 +1,87 @@
+import { handleRequest } from '../../src/cloudflare-workers'
+
+expect.extend({
+  toHaveBeenCalledWithRequest (fetch, req) {
+    try {
+      expect(fetch).toHaveBeenCalledTimes(1)
+
+      const [arg1, arg2] = fetch.mock.calls[0]
+
+      if (typeof arg1 === 'string') {
+        expect({ ...arg2, url: arg1 }).toEqual(req)
+      } else {
+        expect(arg1).toEqual(req)
+      }
+
+      return {
+        pass: true
+      }
+    } catch (err) {
+      return {
+        pass: false,
+        message: () => err.message
+      }
+    }
+  }
+})
+
+describe('Cloudflare Workers', () => {
+  let fetch
+
+  beforeEach(() => {
+    fetch = jest.fn((...args) => {
+      return true
+    })
+    window.fetch = fetch
+  })
+
+  describe('semantic file names for assets', () => {
+    it('does rewrite semantic file names', async () => {
+      await handleRequest({
+        url:
+          'https://assets.serlo.org/58eb97b7e5376_7d4211710d8bab642798e39e07788e6f2912e86a/door-handle.gif'
+      })
+
+      expect(fetch).toHaveBeenCalledWithRequest({
+        url:
+          'https://assets.serlo.org/58eb97b7e5376_7d4211710d8bab642798e39e07788e6f2912e86a.gif'
+      })
+    })
+
+    it('does rewrite semantic file names (legacy)', async () => {
+      await handleRequest({
+        url:
+          'https://assets.serlo.org/legacy/58eb97b7e5376_7d4211710d8bab642798e39e07788e6f2912e86a/door-handle.gif'
+      })
+
+      expect(fetch).toHaveBeenCalledWithRequest({
+        url:
+          'https://assets.serlo.org/legacy/58eb97b7e5376_7d4211710d8bab642798e39e07788e6f2912e86a.gif'
+      })
+    })
+
+    it(`doesn't rewrite non-semantic file names`, async () => {
+      await handleRequest({
+        url:
+          'https://assets.serlo.org/58eb97b7e5376_7d4211710d8bab642798e39e07788e6f2912e86a.gif'
+      })
+
+      expect(fetch).toHaveBeenCalledWithRequest({
+        url:
+          'https://assets.serlo.org/58eb97b7e5376_7d4211710d8bab642798e39e07788e6f2912e86a.gif'
+      })
+    })
+
+    it(`doesn't rewrite non-semantic file names (legacy)`, async () => {
+      await handleRequest({
+        url:
+          'https://assets.serlo.org/legacy/58eb97b7e5376_7d4211710d8bab642798e39e07788e6f2912e86a.gif'
+      })
+
+      expect(fetch).toHaveBeenCalledWithRequest({
+        url:
+          'https://assets.serlo.org/legacy/58eb97b7e5376_7d4211710d8bab642798e39e07788e6f2912e86a.gif'
+      })
+    })
+  })
+})

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
   "scripts": {
     "prebuild": "rimraf dist/",
     "build": "webpack --config webpack.config.prod -p",
+    "build:cf": "webpack --config webpack.config.cf",
     "commit": "git-cz",
     "format":
-      "prettier-standard \"{src/**/*,*}.{js,jsx,ts,tsx,css,less,scss,json}\"",
-    "postformat": "prettier --write \"{src/**/*,*}.md\"",
-    "lint": "standard \"{src/**/*,*}.js\" | snazzy",
+      "prettier-standard \"{{__tests__,src}/**/*,*}.{js,jsx,ts,tsx,css,less,scss,json}\"",
+    "postformat": "prettier --write \"{{__tests__,src}/**/*,*}.md\"",
+    "lint": "standard \"{{__tests__,src}/**/*,*}.js\" | snazzy",
     "semantic-release":
       "semantic-release pre && npm publish && semantic-release post",
     "start": "webpack-dev-server --config webpack.config.dev",

--- a/src/cloudflare-workers/index.js
+++ b/src/cloudflare-workers/index.js
@@ -1,0 +1,24 @@
+addEventListener('fetch', event => {
+  event.respondWith(handleRequest(event.request))
+})
+
+export async function handleRequest (request) {
+  return (
+    (await handleSemanticAssetsFilenames(request)) || (await fetch(request))
+  )
+}
+
+async function handleSemanticAssetsFilenames (request) {
+  const re = /^https:\/\/assets.serlo.org\/(legacy\/|)((?!legacy)\w+)\/([\w\-\+]+)\.(\w+)$/
+  const match = request.url.match(re)
+
+  if (!match) {
+    return null
+  }
+
+  const [_url, prefix, hash, name, extension] = match
+  return await fetch(
+    `https://assets.serlo.org/${prefix}${hash}.${extension}`,
+    request
+  )
+}

--- a/src/cloudflare-workers/index.js
+++ b/src/cloudflare-workers/index.js
@@ -1,23 +1,28 @@
+/* eslint-env browser, serviceworker */
 addEventListener('fetch', event => {
   event.respondWith(handleRequest(event.request))
 })
 
 export async function handleRequest (request) {
-  return (
+  const response =
     (await handleSemanticAssetsFilenames(request)) || (await fetch(request))
-  )
+
+  return response
 }
 
 async function handleSemanticAssetsFilenames (request) {
-  const re = /^https:\/\/assets.serlo.org\/(legacy\/|)((?!legacy)\w+)\/([\w\-\+]+)\.(\w+)$/
+  const re = /^https:\/\/assets.serlo.org\/(legacy\/|)((?!legacy)\w+)\/([\w\-+]+)\.(\w+)$/
   const match = request.url.match(re)
 
   if (!match) {
     return null
   }
 
-  const [_url, prefix, hash, name, extension] = match
-  return await fetch(
+  const prefix = match[1]
+  const hash = match[2]
+  const extension = match[4]
+
+  return fetch(
     `https://assets.serlo.org/${prefix}${hash}.${extension}`,
     request
   )

--- a/webpack.config.cf.js
+++ b/webpack.config.cf.js
@@ -1,0 +1,11 @@
+const path = require('path')
+
+module.exports = {
+  target: 'webworker',
+  entry: './src/cloudflare-workers',
+  output: {
+    path: path.resolve(__dirname, 'dist-cf'),
+    filename: 'index.js',
+    publicPath: '/'
+  }
+}


### PR DESCRIPTION
Closes https://github.com/serlo-org/athene2/issues/647. Rewrites the urls as discussed in the issue. The newly created cloudflare-workers.js has to be inserted into www.cloudflare.com but it's here so that we have a file history (we could update the script in our CI by using Cloudflare API)

Also uses athene2-assets test + build pipeline (so you can use NPM packages if you want).