### PR TITLE
fix: remove String.startsWith for IE compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Remove explicit target on `@babel/preset-env` so that [Browserlist's](https://github.com/browserslist/browserslist) recommended config is used
+
+### Fixed
+
+- Replace usages of `String.startsWith` for IE compatibility
+
 ## [3.0.0] - 2017-10-30
 
 ### Added

--- a/babel.config.js
+++ b/babel.config.js
@@ -3,14 +3,7 @@ module.exports = api => {
   api.cache(isProduction)
 
   const presets = [
-    [
-      '@babel/preset-env',
-      {
-        targets: {
-          browsers: ['>0.25%']
-        }
-      }
-    ],
+    '@babel/preset-env',
     '@babel/preset-typescript',
     '@babel/preset-react',
     '@babel/preset-flow'

--- a/src/main/modules/serlo_content_api.js
+++ b/src/main/modules/serlo_content_api.js
@@ -33,7 +33,7 @@ export const initContentApi = () => {
     const target = $link.attr('target')
 
     const isInternalLink =
-      url && (url.startsWith('/') || url.startsWith(origin))
+      url && (url[0] === '/' || url.substr(0, origin.length) === origin)
     const isBlank = target && target === '_blank'
 
     if (isInternalLink && !isBlank) {


### PR DESCRIPTION
Closes https://github.com/serlo-org/athene2/issues/772

## Changelog

### Changed

* Remove explicit target on `@babel/preset-env` so that [Browserlist's](https://github.com/browserslist/browserslist) recommended config is used

### Fixed

* Replace usages of `String.startsWith` for IE compatibility