### PR TITLE
fix: set max filesize of old image-upload to 2MB

### DIFF
--- a/src/legacy-editor/index.js
+++ b/src/legacy-editor/index.js
@@ -516,7 +516,7 @@ $(function() {
           type: 'post',
           url: '/attachment/upload',
           paramName: 'attachment[file]',
-          loadImageMaxFileSize: 8000000,
+          loadImageMaxFileSize: 2 * 1024 * 1024,
           maxNumberOfFiles: 1
         })
       )


### PR DESCRIPTION
fixes https://github.com/serlo-org/athene2/issues/234